### PR TITLE
fix: ControllerAdvice를 스웨거에게 숨겨 충돌 방지하도록 수정

### DIFF
--- a/src/main/java/my/fisherman/fisherman/global/exception/FishermanExceptionHandler.java
+++ b/src/main/java/my/fisherman/fisherman/global/exception/FishermanExceptionHandler.java
@@ -1,9 +1,11 @@
 package my.fisherman.fisherman.global.exception;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Hidden
 @RestControllerAdvice
 public class FishermanExceptionHandler {
 


### PR DESCRIPTION
### 관련 이슈
#41 

---
### 작업 내용
스웨거와 컨트롤러 어드바이스가 충돌하는 오류를 해결했습니다.

---
### 리뷰어 참고 & 요구 사항
- [참고](https://github.com/springdoc/springdoc-openapi/issues/374)

---
### 현재 버그
없습니도
