### PR TITLE
fix: Letter의 title 필드와 Quiz의 content 필드 제거

### DIFF
--- a/src/main/java/my/fisherman/fisherman/fishingspot/api/request/FishingSpotRequest.java
+++ b/src/main/java/my/fisherman/fisherman/fishingspot/api/request/FishingSpotRequest.java
@@ -17,9 +17,6 @@ public class FishingSpotRequest {
         @NotNull(message = "빙어 종류 ID는 필수입니다.")
         @Positive(message = "빙어 종류 ID는 양수여야 합니다.")
         Long smeltTypeId,
-        @NotBlank(message = "편지 제목은 필수입니다.")
-        @Length(max = 15, message = "편지의 제목은 15자 이하여야 합니다.")
-        String title,
         @NotBlank(message = "편지 내용은 필수입니다.")
         @Length(max = 300, message = "편지의 내용은 300자 이하여야 합니다.")
         String content,
@@ -35,11 +32,9 @@ public class FishingSpotRequest {
                 smeltTypeId,
                 fishingSpotId,
                 senderName,
-                title,
                 content,
                 quiz.isPresent(),
                 quiz.map(Quiz::title).orElse(null),
-                quiz.map(Quiz::content).orElse(null),
                 quiz.map(Quiz::type).orElse(null),
                 quiz.map(Quiz::questions).orElse(null),
                 quiz.map(Quiz::answerIndex).orElse(null)
@@ -50,8 +45,6 @@ public class FishingSpotRequest {
     record Quiz(
         @Length(max=30, message = "퀴즈의 질문은 30자 이하여야 합니다.")
         String title,
-        @Length(max=100, message = "퀴즈의 내용은 100자 이하여야 합니다.")
-        String content,
         String type,
         @Size(min=2, max=4, message = "퀴즈의 선지는 2~4개여야 합니다.")
         List<String> questions,

--- a/src/main/java/my/fisherman/fisherman/fishingspot/api/response/FishingSpotResponse.java
+++ b/src/main/java/my/fisherman/fisherman/fishingspot/api/response/FishingSpotResponse.java
@@ -54,11 +54,10 @@ public class FishingSpotResponse {
         Long id,
         String senderName,
         String title,
-        String content,
         String createdTime
     ) {
         static Letter from(FishingSpotInfo.LetterInfo info) {
-            return new Letter(info.id(), info.senderName(), info.title(), info.content(), info.createdTime().toString());
+            return new Letter(info.id(), info.senderName(), info.title(), info.createdTime().toString());
         }
     }
 

--- a/src/main/java/my/fisherman/fisherman/fishingspot/application/command/FishingSpotCommand.java
+++ b/src/main/java/my/fisherman/fisherman/fishingspot/application/command/FishingSpotCommand.java
@@ -8,11 +8,9 @@ public class FishingSpotCommand {
         Long smeltTypeId,
         Long fishingSpotId,
         String senderName,
-        String letterTitle,
         String letterContent,
         Boolean existQuiz,
         String quizTitle,
-        String quizContent,
         String quiztype,
         List<String> questions,
         int answerIndex

--- a/src/main/java/my/fisherman/fisherman/fishingspot/application/dto/FishingSpotInfo.java
+++ b/src/main/java/my/fisherman/fisherman/fishingspot/application/dto/FishingSpotInfo.java
@@ -110,11 +110,10 @@ public class FishingSpotInfo {
         Long id,
         String senderName,
         String title,
-        String content,
         LocalDateTime createdTime
     ) {
         public static LetterInfo from(Letter letter) {
-            return new LetterInfo(letter.getId(), letter.getSenderName(), letter.getTitle(), letter.getContent(), letter.getCreatedTime());
+            return new LetterInfo(letter.getId(), letter.getSenderName(), letter.getContent(), letter.getCreatedTime());
         }
     }
 }

--- a/src/main/java/my/fisherman/fisherman/smelt/domain/Letter.java
+++ b/src/main/java/my/fisherman/fisherman/smelt/domain/Letter.java
@@ -27,9 +27,6 @@ public class Letter {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "letter_title", nullable = false)
-    private String title;
-
     @Column(name = "letter_content", nullable = false)
     private String content;
 
@@ -45,7 +42,6 @@ public class Letter {
 
     private Letter(String title, String content, String senderName) {
         this.id = null;
-        this.title = title;
         this.content = content;
         this.senderName = senderName;
         this.createdTime = LocalDateTime.now();


### PR DESCRIPTION
### 관련 이슈
#77 

---
### 작업 내용
편지와 퀴즈에서 각각 제목과 본문 필드를 제거했습니다.

---
### 리뷰어 참고 & 요구 사항
x

---
### 현재 버그
x
