### PR TITLE
fix: Letter의 title 필드와 Quiz의 content 필드 제거

### DIFF
--- a/src/main/java/my/fisherman/fisherman/fishingspot/application/FishingSpotService.java
+++ b/src/main/java/my/fisherman/fisherman/fishingspot/application/FishingSpotService.java
@@ -101,7 +101,7 @@ public class FishingSpotService {
         FishingSpot fishingSpot = fishingSpotRepository.findById(command.fishingSpotId())
                 .orElseThrow(() -> new FishermanException(FishingSpotErrorCode.NOT_FOUND, "낚시터 %d을/를 찾을 수 없습니다.".formatted(command.fishingSpotId())));
 
-        Letter letter = Letter.of(command.letterTitle(), command.letterContent(), command.senderName());
+        Letter letter = Letter.of(command.letterContent(), command.senderName());
         Quiz quiz = null;
         List<Question> questions = null;
         if (command.existQuiz()) {

--- a/src/main/java/my/fisherman/fisherman/inventory/api/response/InventoryResponse.java
+++ b/src/main/java/my/fisherman/fisherman/inventory/api/response/InventoryResponse.java
@@ -96,7 +96,6 @@ public class InventoryResponse {
             Long id,
             String senderName,
             String title,
-            String content,
             String createdTime,
             Comment comment
     ) {
@@ -105,7 +104,6 @@ public class InventoryResponse {
                     info.id(),
                     info.senderName(),
                     info.title(),
-                    info.content(),
                     info.createdTime().toString(),
                     info.commentInfo() != null ? Comment.from(info.commentInfo()) : null
             );

--- a/src/main/java/my/fisherman/fisherman/inventory/application/dto/InventoryInfo.java
+++ b/src/main/java/my/fisherman/fisherman/inventory/application/dto/InventoryInfo.java
@@ -72,7 +72,6 @@ public class InventoryInfo {
             Long id,
             String senderName,
             String title,
-            String content,
             LocalDateTime createdTime,
             CommentInfo commentInfo
     ) {
@@ -80,7 +79,6 @@ public class InventoryInfo {
             return new LetterInfo(
                     letter.getId(),
                     letter.getSenderName(),
-                    letter.getTitle(),
                     letter.getContent(),
                     letter.getCreatedTime(),
                     letter.getComment() != null ? CommentInfo.from(letter.getComment()) : null

--- a/src/main/java/my/fisherman/fisherman/smelt/api/response/SmeltResponse.java
+++ b/src/main/java/my/fisherman/fisherman/smelt/api/response/SmeltResponse.java
@@ -38,7 +38,6 @@ public class SmeltResponse {
 
     record Letter (
         Long id,
-        String title,
         String content,
         String senderName,
         LocalDateTime createdTime,
@@ -49,7 +48,7 @@ public class SmeltResponse {
                 return null;
             }
 
-            return new Letter(info.id(), info.title(), info.content(), info.senderName(), info.createdTime(), Comment.from(info.comment()));
+            return new Letter(info.id(), info.content(), info.senderName(), info.createdTime(), Comment.from(info.comment()));
         }
     }
 

--- a/src/main/java/my/fisherman/fisherman/smelt/application/dto/SmeltInfo.java
+++ b/src/main/java/my/fisherman/fisherman/smelt/application/dto/SmeltInfo.java
@@ -42,7 +42,6 @@ public class SmeltInfo {
 
     public record LetterInfo(
         Long id,
-        String title,
         String content,
         String senderName,
         LocalDateTime createdTime,
@@ -55,7 +54,6 @@ public class SmeltInfo {
 
             return new LetterInfo(
                 letter.getId(),
-                letter.getTitle(),
                 letter.getContent(),
                 letter.getSenderName(),
                 letter.getCreatedTime(),

--- a/src/main/java/my/fisherman/fisherman/smelt/domain/Letter.java
+++ b/src/main/java/my/fisherman/fisherman/smelt/domain/Letter.java
@@ -40,7 +40,7 @@ public class Letter {
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private Comment comment;
 
-    private Letter(String title, String content, String senderName) {
+    private Letter(String content, String senderName) {
         this.id = null;
         this.content = content;
         this.senderName = senderName;
@@ -48,8 +48,8 @@ public class Letter {
         this.comment = null;
     }
 
-    public static Letter of(String title, String content, String senderName) {
-        return new Letter(title, content, senderName);
+    public static Letter of(String content, String senderName) {
+        return new Letter(content, senderName);
     }
 
     public void registerComment(Comment comment) {


### PR DESCRIPTION
### 관련 이슈
#77 

---
### 작업 내용
편지와 퀴즈에서 각각 제목과 내용 필드를 제거했습니다.

---
### 리뷰어 참고 & 요구 사항
x

---
### 현재 버그
x
