### PR TITLE
Hotfix/inventory-api

### DIFF
--- a/src/main/java/my/fisherman/fisherman/inventory/api/response/InventoryResponse.java
+++ b/src/main/java/my/fisherman/fisherman/inventory/api/response/InventoryResponse.java
@@ -76,6 +76,7 @@ public class InventoryResponse {
             String fishermanNickname,
             Long smeltTypeId,
             String status,
+            Short wrongCount,
             Letter letter
     ) {
         static SmeltDetail from(InventoryInfo.DetailSmelt info) {
@@ -86,6 +87,7 @@ public class InventoryResponse {
                     info.nickname(),
                     info.smeltInfo().smeltTypeId(),
                     info.smeltInfo().status().name(),
+                    info.wrongCount(),
                     info.letterInfo() != null ? Letter.from(info.letterInfo()) : null
             );
         }

--- a/src/main/java/my/fisherman/fisherman/inventory/application/dto/InventoryInfo.java
+++ b/src/main/java/my/fisherman/fisherman/inventory/application/dto/InventoryInfo.java
@@ -57,13 +57,15 @@ public class InventoryInfo {
     public record DetailSmelt(
             String nickname,
             SmeltInfo smeltInfo,
-            LetterInfo letterInfo
+            LetterInfo letterInfo,
+            Short wrongCount
     ) {
         public static DetailSmelt from(Smelt smelt) {
             return new DetailSmelt(
                     smelt.getFishingSpot() != null ? smelt.getFishingSpot().getFisherman().getNickname() : null,
                     SmeltInfo.from(smelt),
-                    smelt.getLetter() != null ? LetterInfo.from(smelt.getLetter()) : null
+                    smelt.getLetter() != null ? LetterInfo.from(smelt.getLetter()) : null,
+                    smelt.getQuiz() == null ? 0 : smelt.getQuiz().getWrongCount()
             );
         }
     }


### PR DESCRIPTION
### 관련 이슈
#86 

---
### 작업 내용
- 보낸 빙어 조회 응답에 틀린 횟수 정보를 포함합니다.
- 빙어의 상태와 무관하게 틀린 횟수가 포함됩니다 (받은 사람이 아직 풀었어도 보낸 사람은 조회 가능)
- 빙어에 퀴즈가 없는 경우 0으로 반환됩니다.

