### PR TITLE
Hotfix/fishingspot public

### DIFF
--- a/src/main/java/my/fisherman/fisherman/fishingspot/domain/FishingSpot.java
+++ b/src/main/java/my/fisherman/fisherman/fishingspot/domain/FishingSpot.java
@@ -45,6 +45,7 @@ public class FishingSpot {
     public void updatePublic(Long userId, Boolean isPublic) {
         if (this.fisherman.getId().equals(userId)) {
             this.isPublic = isPublic;
+            return;
         }
 
         throw new FishermanException(FishingSpotErrorCode.FORBIDDEN);


### PR DESCRIPTION
### 관련 이슈
#97 

---
### 작업 내용
검색 허용 수정 후 누락된 얼리 리턴문을 추가해 403 응답을 방지합니다.

---
### 리뷰어 참고 & 요구 사항
x

---
### 현재 버그
x
